### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,5 @@ cobra.test
 bin
 
 .idea/
+.vscode/
 *.iml


### PR DESCRIPTION
I use the Go debugger through VSCode and the debugger launch files are stored under `.vscode/`.
This one-liner simply `.vscode/` adds it to the `.gitignore` file.