### PR TITLE
ci: add workflow_dispatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 env:
   GO111MODULE: on


### PR DESCRIPTION
The workflow dispatch event allows maintainers or forkers to trigger CI runs either through the web GUI or through the API. See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch.