### PR TITLE
fix: replace viper with useViper in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ An example ~/.cobra.yaml file:
 ```yaml
 author: Steve Francia <spf@spf13.com>
 license: MIT
-viper: true
+useViper: true
 ```
 
 You can also use built-in licenses. For example, **GPLv2**, **GPLv3**, **LGPL**,


### PR DESCRIPTION
The flag `viper` in `~/.cobra.yaml` example has no impact.
The correct flag is `useViper` according to source code of cobra-cli.