### PR TITLE
[RFC] Add ActiveHelp to the cobra-cli

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -37,7 +37,17 @@ If you want your command to be public, pass in the command name
 with an initial uppercase letter.
 
 Example: cobra add server -> resulting in a new cmd/server.go`,
-
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			var comps []string
+			if len(args) == 0 {
+				comps = cobra.AppendActiveHelp(comps, "Please specify the name for the new command")
+			} else if len(args) == 1 {
+				comps = cobra.AppendActiveHelp(comps, "This command does not take any more arguments (but may accept flags)")
+			} else {
+				comps = cobra.AppendActiveHelp(comps, "ERROR: Too many arguments specified")
+			}
+			return comps, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) < 1 {
 				cobra.CheckErr(fmt.Errorf("add needs a name for the command"))

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,7 +36,21 @@ and the appropriate structure for a Cobra-based CLI application.
 
 Cobra init must be run inside of a go module (please run "go mod init <MODNAME>" first)
 `,
-
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			var comps []string
+			var directive cobra.ShellCompDirective
+			if len(args) == 0 {
+				comps = cobra.AppendActiveHelp(comps, "Optionally specify the path of the go module to initialize")
+				directive = cobra.ShellCompDirectiveDefault
+			} else if len(args) == 1 {
+				comps = cobra.AppendActiveHelp(comps, "This command does not take any more arguments (but may accept flags)")
+				directive = cobra.ShellCompDirectiveNoFileComp
+			} else {
+				comps = cobra.AppendActiveHelp(comps, "ERROR: Too many arguments specified")
+				directive = cobra.ShellCompDirectiveNoFileComp
+			}
+			return comps, directive
+		},
 		Run: func(_ *cobra.Command, args []string) {
 			projectPath, err := initializeProject(args)
 			cobra.CheckErr(err)

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.10.1
 )
+
+replace github.com/spf13/cobra => github.com/VilledeMontreal/cobra v0.0.6-0.20220315145727-d9d9c3eff689

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/VilledeMontreal/cobra v0.0.6-0.20220315145727-d9d9c3eff689 h1:gpprwCSiu/KFJFY2zMbCaP+oS9ZiZTTPzDJkq0pRZM0=
+github.com/VilledeMontreal/cobra v0.0.6-0.20220315145727-d9d9c3eff689/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -308,8 +310,6 @@ github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
-github.com/spf13/cobra v1.4.0/go.mod h1:Wo4iy3BUC+X2Fybo0PDqwJIv3dNRiZLHQymsfxlB84g=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
To make it easier to test the ActiveHelp feature proposed in https://github.com/spf13/cobra/pull/1482, this draft PR adds activeHelp messages to the cobra-cli.

To test:
1. checkout the PR branch
2. make (the go.mod in the PR points to the ActiveHelp commit in Cobra)
3. source the updated shell completion script
For zsh on Mac:
```
source <(bin/cobra-cli_darwin_amd64 completion zsh)
compdef _cobra-cli cobra-cli
compdef _cobra-cli cobra-cli_darwin_amd64
```
For bash on Mac:
```
source <(bin/cobra-cli_darwin_amd64 completion bash)
complete -o default -F __start_cobra-cli cobra-cli_darwin_amd64
```
Then try out the ActiveHelp triggers:
```
$ bin/cobra-cli_darwin_amd64 init <TAB>
Optionally specify the path of the go module to initialize
--
CONDUCT.md       LICENSE.txt      Makefile         bin/             go.mod           main.go
CONTRIBUTING.md  MAINTAINERS      README.md        cmd/             go.sum           tpl/

$ bin/cobra-cli_darwin_amd64 init newprogram <TAB>
This command does not take any more arguments (but may accept flags)

$ bin/cobra-cli_darwin_amd64 init newprogram extra <TAB>
ERROR: Too many arguments specified

$ bin/cobra-cli_darwin_amd64 add <TAB>
Please specify the name for the new command

$ bin/cobra-cli_darwin_amd64 add command <TAB>
This command does not take any more arguments (but may accept flags)

$ bin/cobra-cli_darwin_amd64 add command command2 <TAB>
ERROR: Too many arguments specified
```
You can compare the new behaviour with the old one by running the same commands but using and the master branch of the `cobra-cli` installed on your workstation, e.g.,
```
$ cobra-cli add <TAB>
CONDUCT.md       LICENSE.txt      Makefile         bin/             go.mod           main.go
CONTRIBUTING.md  MAINTAINERS      README.md        cmd/             go.sum           tpl/
```
