### PR TITLE
Change "an" to "a" before "Cobra"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd myapp
 go mod init github.com/spf13/myapp
 ```
 
-#### Initalizing an Cobra CLI application
+#### Initalizing a Cobra CLI application
 
 From within a Go module run `cobra-cli init`. This will create a new barebones project
 for you to edit. 


### PR DESCRIPTION
As cobra begins with c, a consonant, the proper indefinite article to precede it is "a." The article "an" generally should only precede words starting with vowels or occasionally the letter h.