### PR TITLE
Add ActiveHelp to the cobra-cli

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -37,7 +37,17 @@ If you want your command to be public, pass in the command name
 with an initial uppercase letter.
 
 Example: cobra add server -> resulting in a new cmd/server.go`,
-
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			var comps []string
+			if len(args) == 0 {
+				comps = cobra.AppendActiveHelp(comps, "Please specify the name for the new command")
+			} else if len(args) == 1 {
+				comps = cobra.AppendActiveHelp(comps, "This command does not take any more arguments (but may accept flags)")
+			} else {
+				comps = cobra.AppendActiveHelp(comps, "ERROR: Too many arguments specified")
+			}
+			return comps, cobra.ShellCompDirectiveNoFileComp
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) < 1 {
 				cobra.CheckErr(fmt.Errorf("add needs a name for the command"))

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,7 +36,21 @@ and the appropriate structure for a Cobra-based CLI application.
 
 Cobra init must be run inside of a go module (please run "go mod init <MODNAME>" first)
 `,
-
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			var comps []string
+			var directive cobra.ShellCompDirective
+			if len(args) == 0 {
+				comps = cobra.AppendActiveHelp(comps, "Optionally specify the path of the go module to initialize")
+				directive = cobra.ShellCompDirectiveDefault
+			} else if len(args) == 1 {
+				comps = cobra.AppendActiveHelp(comps, "This command does not take any more arguments (but may accept flags)")
+				directive = cobra.ShellCompDirectiveNoFileComp
+			} else {
+				comps = cobra.AppendActiveHelp(comps, "ERROR: Too many arguments specified")
+				directive = cobra.ShellCompDirectiveNoFileComp
+			}
+			return comps, directive
+		},
 		Run: func(_ *cobra.Command, args []string) {
 			projectPath, err := initializeProject(args)
 			cobra.CheckErr(err)


### PR DESCRIPTION
This PR adds ActiveHelp to the cobra-cli as an example of the new ActiveHelp feature.

This is a revival of #24 which I was not able to re-open.
Since the original PR was done from the VilledeMontreal organization, I wanted to finish the work there to give proper credit.

To test:
1. checkout the PR branch
2. make (the go.mod in the PR points to the ActiveHelp commit in Cobra)
3. source the updated shell completion script
For zsh on Mac:
```
source <(bin/cobra-cli_darwin_amd64 completion zsh)
compdef _cobra-cli cobra-cli
compdef _cobra-cli cobra-cli_darwin_amd64
```
For bash on Mac:
```
source <(bin/cobra-cli_darwin_amd64 completion bash)
complete -o default -F __start_cobra-cli cobra-cli_darwin_amd64
```
Then try out the ActiveHelp triggers:
```
$ bin/cobra-cli_darwin_amd64 init <TAB>
Optionally specify the path of the go module to initialize
--
CONDUCT.md       LICENSE.txt      Makefile         bin/             go.mod           main.go
CONTRIBUTING.md  MAINTAINERS      README.md        cmd/             go.sum           tpl/

$ bin/cobra-cli_darwin_amd64 init newprogram <TAB>
This command does not take any more arguments (but may accept flags)

$ bin/cobra-cli_darwin_amd64 init newprogram extra <TAB>
ERROR: Too many arguments specified

$ bin/cobra-cli_darwin_amd64 add <TAB>
Please specify the name for the new command

$ bin/cobra-cli_darwin_amd64 add command <TAB>
This command does not take any more arguments (but may accept flags)

$ bin/cobra-cli_darwin_amd64 add command command2 <TAB>
ERROR: Too many arguments specified
```
You can compare the new behaviour with the old one by running the same commands but using the main branch or the `cobra-cli` installed on your workstation, e.g.,
```
$ cobra-cli add <TAB>
CONDUCT.md       LICENSE.txt      Makefile         bin/             go.mod           main.go
CONTRIBUTING.md  MAINTAINERS      README.md        cmd/             go.sum           tpl/
```
