### PR TITLE
Introduce new version sub command (issue #49)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ XC_ARCH="amd64"
 XC_PARALLEL="2"
 BIN="bin"
 SRC=$(shell find . -name "*.go")
-
+GIT_SHA?=$(shell git rev-parse HEAD)
+VERSION?=$(shell git describe --always --tags | cut -d "v" -f 2)
+LINKER_FLAGS="-s -w -X github.com/spf13/cobra-cli/cmd.Version=${VERSION} -X github.com/spf13/cobra-cli/cmd.GitCommit=${GIT_SHA}"
 ifeq (, $(shell which golangci-lint))
 $(warning "could not find golangci-lint in $(PATH), run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh")
 endif
@@ -27,6 +29,7 @@ build: install_deps
 		-os=$(XC_OS) \
 		-arch=$(XC_ARCH) \
 		-parallel=$(XC_PARALLEL) \
+		-ldflags=$(LINKER_FLAGS) \
 		-output=$(BIN)/{{.Dir}}_{{.OS}}_{{.Arch}} \
 		;
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,19 +17,32 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
+const verTemplate = `cobra-cli version: %s
+git version: %s
+Go version: %s
+   os: %s
+   arch: %s
+   compiler: %s
+`
+
 var (
+	Version   string
+	GitCommit string
+
 	// Used for flags.
 	cfgFile     string
 	userLicense string
 
 	rootCmd = &cobra.Command{
-		Use:   "cobra-cli",
-		Short: "A generator for Cobra based Applications",
+		Use:     "cobra-cli",
+		Version: Version,
+		Short:   "A generator for Cobra based Applications",
 		Long: `Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
@@ -55,6 +68,8 @@ func init() {
 
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(initCmd)
+
+	rootCmd.SetVersionTemplate(formattedVersion())
 }
 
 func initConfig() {
@@ -86,4 +101,14 @@ func initConfig() {
 	default:
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
+}
+
+func formattedVersion() string {
+	return fmt.Sprintf(verTemplate,
+		Version,
+		GitCommit,
+		runtime.Version(),
+		runtime.GOOS,
+		runtime.GOARCH,
+		runtime.Compiler)
 }


### PR DESCRIPTION

**Description:**
This PR adds a version subcommand.


```
./bin/cobra-cli_darwin_amd64 --version
cobra-cli version: 1.3.0-13-gd146541
git version: d146541ba2222bd380b125b10f92ed0e1cc98109
Go version: go1.18.3
   os: darwin
   arch: amd64
   compiler: gc
```


Closes: #49 
