### PR TITLE
Prevent cobra from overwriting files by default

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -43,6 +43,9 @@ Example: cobra add server -> resulting in a new cmd/server.go`,
 				cobra.CheckErr(fmt.Errorf("add needs a name for the command"))
 			}
 
+			force, err := cmd.Flags().GetBool("force")
+			cobra.CheckErr(err)
+
 			wd, err := os.Getwd()
 			cobra.CheckErr(err)
 
@@ -57,7 +60,7 @@ Example: cobra add server -> resulting in a new cmd/server.go`,
 				},
 			}
 
-			cobra.CheckErr(command.Create())
+			cobra.CheckErr(command.Create(force))
 
 			fmt.Printf("%s created at %s\n", command.CmdName, command.AbsolutePath)
 		},
@@ -67,6 +70,7 @@ Example: cobra add server -> resulting in a new cmd/server.go`,
 func init() {
 	addCmd.Flags().StringVarP(&packageName, "package", "t", "", "target package name (e.g. github.com/spf13/hugo)")
 	addCmd.Flags().StringVarP(&parentName, "parent", "p", "rootCmd", "variable name of parent command for this command")
+	addCmd.Flags().BoolP("force", "f", false, "overwrite files")
 	cobra.CheckErr(addCmd.Flags().MarkDeprecated("package", "this operation has been removed."))
 }
 

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -27,6 +27,12 @@ func TestGoldenAddCmd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// cobra-init should fail to overwrite existing files without --force
+	assertErr(t, command.Create(false))
+
+	// cobra-init should sucessfully overwrite existing files with --force
+	assertNoErr(t, command.Create(true))
 }
 
 func TestValidateCmdName(t *testing.T) {

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -18,8 +18,8 @@ func TestGoldenAddCmd(t *testing.T) {
 	}
 	defer os.RemoveAll(command.AbsolutePath)
 
-	assertNoErr(t, command.Project.Create())
-	assertNoErr(t, command.Create())
+	assertNoErr(t, command.Project.Create(false))
+	assertNoErr(t, command.Create(false))
 
 	generatedFile := fmt.Sprintf("%s/cmd/%s.go", command.AbsolutePath, command.CmdName)
 	goldenFile := fmt.Sprintf("testdata/%s.go.golden", command.CmdName)

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,9 +1,18 @@
 package cmd
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func assertNoErr(t *testing.T, e error) {
 	if e != nil {
 		t.Error(e)
+	}
+}
+
+func assertErr(t *testing.T, e error) {
+	if e == nil {
+		t.Error(fmt.Errorf("expected error but not error occurred"))
 	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -37,8 +37,10 @@ and the appropriate structure for a Cobra-based CLI application.
 Cobra init must be run inside of a go module (please run "go mod init <MODNAME>" first)
 `,
 
-		Run: func(_ *cobra.Command, args []string) {
-			projectPath, err := initializeProject(args)
+		Run: func(cmd *cobra.Command, args []string) {
+			force, err := cmd.Flags().GetBool("force")
+			cobra.CheckErr(err)
+			projectPath, err := initializeProject(force, args)
 			cobra.CheckErr(err)
 			cobra.CheckErr(goGet("github.com/spf13/cobra"))
 			if viper.GetBool("useViper") {
@@ -49,7 +51,11 @@ Cobra init must be run inside of a go module (please run "go mod init <MODNAME>"
 	}
 )
 
-func initializeProject(args []string) (string, error) {
+func init() {
+	initCmd.Flags().BoolP("force", "f", false, "overwrite files")
+}
+
+func initializeProject(force bool, args []string) (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -72,7 +78,7 @@ func initializeProject(args []string) (string, error) {
 		AppName:      path.Base(modName),
 	}
 
-	if err := project.Create(); err != nil {
+	if err := project.Create(force); err != nil {
 		return "", err
 	}
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -49,7 +49,7 @@ func TestGoldenInitCmd(t *testing.T) {
 
 			viper.Set("useViper", true)
 			viper.Set("license", "apache")
-			projectPath, err := initializeProject(tt.args)
+			projectPath, err := initializeProject(false, tt.args)
 			defer func() {
 				if projectPath != "" {
 					os.RemoveAll(projectPath)

--- a/cmd/testdata/main.go.golden
+++ b/cmd/testdata/main.go.golden
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © {{ .Year }} NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/testdata/root.go.golden
+++ b/cmd/testdata/root.go.golden
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © {{ .Year }} NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/testdata/test.go.golden
+++ b/cmd/testdata/test.go.golden
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © {{ .Year }} NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Running `cobra-cli init` or `cobra-cli add` would overwrite existing files without warning, which could result in unexpected loss of data. This commit modifies cobra-cli so that by default it will not overwrite files, and adds the `--force` flag to the `init` and `add` subcommands to allow it to overwrite files.

Closes #59