### PR TITLE
Templates for commands via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Cobra provides its own program that will create your application and add any
 commands you want. It's the easiest way to incorporate Cobra into your application.
 
-Install the cobra generator with the command `go install github.com/spf13/cobra-cli@latest`. 
+Install the cobra generator with the command `go install github.com/nerdlem/cobra-cli@latest`. 
 Go will automatically install it in your `$GOPATH/bin` directory which should be in your $PATH. 
 
 Once installed you should have the `cobra-cli` command available. Confirm by typing `cobra-cli` at a 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -17,7 +17,7 @@ func getProject() *Project {
 		Legal:        getLicense(),
 		Copyright:    copyrightLine(),
 		AppName:      "cmd",
-		PkgName:      "github.com/spf13/cobra-cli/cmd/cmd",
+		PkgName:      "github.com/nerdlem/cobra-cli/cmd/cmd",
 		Viper:        true,
 	}
 }

--- a/cmd/testdata/main.go.golden
+++ b/cmd/testdata/main.go.golden
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package main
 
-import "github.com/spf13/cobra-cli/cmd/cmd"
+import "github.com/nerdlem/cobra-cli/cmd/cmd"
 
 func main() {
 	cmd.Execute()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/spf13/cobra-cli
+module github.com/nerdlem/cobra-cli
 
 go 1.15
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ package main
 import (
 	"os"
 
-	"github.com/spf13/cobra-cli/cmd"
+	"github.com/nerdlem/cobra-cli/cmd"
 )
 
 func main() {


### PR DESCRIPTION
This set of changes allow for adding custom command contents to be used by the generator, via templates.

Changes to the README.md file should not be added, but were left just as documentation.

Thanks!