### PR TITLE
Update the link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ with `go run main.go help serve`, etc. would all work.
 
 You now have a basic Cobra-based application up and running. Next step is to edit the files in cmd and customize them for your application.
 
-For complete details on using the Cobra library, please read the [The Cobra User Guide](https://github.com/spf13/cobra/blob/master/user_guide.md#using-the-cobra-library).
+For complete details on using the Cobra library, please read the [The Cobra User Guide](https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#using-the-cobra-library).
 
 Have fun!
 


### PR DESCRIPTION
The current link for the Cobra User Guide leads [here](https://github.com/spf13/cobra/blob/master/user_guide.md#using-the-cobra-library) which is a 404. The correct link is [this](https://github.com/spf13/cobra/blob/main/site/content/user_guide.md#using-the-cobra-library).