### PR TITLE
github: update workflow 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
         - ubuntu
         - macOS
         go:
-        - 14
-        - 15
-        - 16
         - 17
+        - 18
+        - 19
+        - 20
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     steps:


### PR DESCRIPTION
- remove go versions: 1.14-1.17