### PR TITLE
ci: github fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.${{ matrix.go }}.x
+        check-latest: true
+
 
     - uses: actions/checkout@v3.1.0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,10 @@ jobs:
         - ubuntu
         - macOS
         go:
-        - 14
-        - 15
-        - 16
         - 17
+        - 18
+        - 19
+        - 20
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     steps:


### PR DESCRIPTION
- Remove go versions 1.14-17
- Add go versions 1.18-l.20