### PR TITLE
Allow initialization of cobra project from within a go workspace/monorepo. resolves spf13/cobra-cli#26

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -135,7 +135,11 @@ func goGet(mod string) error {
 
 func modInfoJSON(args ...string) []byte {
 	cmdArgs := append([]string{"list", "-json"}, args...)
-	out, err := exec.Command("go", cmdArgs...).Output()
+
+	cmd := exec.Command("go", cmdArgs...)
+	cmd.Env = append(cmd.Env, "GOWORK=off")
+
+	out, err := cmd.Output()
 	cobra.CheckErr(err)
 
 	return out


### PR DESCRIPTION
Resolves [spf13/cobra-cli#26](https://github.com/spf13/cobra-cli/issues/26)

Running `cobra-cli init...` in a module that is part of a go workspace fails because of a JSON parsing error. The error is the result of expecting a single object from the command `go list -json -m` but receiving multiple objects - one for each of the modules in the workspace.

By setting the environment variable GOWORK=off before running cobra-cli, the `go list -json -m` command reverts back to returning the single object cobra-cli expects.

An alternative solution would be to parse the output of the `go list -json -m` command with a `json.Decoder` rather than `json.Unmarshal` and match the module directory to the correct object decoded. The environment variable solution implemented here seemed cleaner to implement - however should cobra-cli require further interaction with workspaces going forward, using `json.Decoder` may be a more appropriate approach, at which point this environment variable must be removed.

No new tests were created for this fix as none of the existing tests pass as is.