### PR TITLE
fix: reuse existing license if user didn't set any

### DIFF
--- a/cmd/project.go
+++ b/cmd/project.go
@@ -72,7 +72,17 @@ func (p *Project) createLicenseFile() error {
 	data := map[string]interface{}{
 		"copyright": copyrightLine(),
 	}
-	licenseFile, err := os.Create(fmt.Sprintf("%s/LICENSE", p.AbsolutePath))
+
+	licensePath := p.AbsolutePath + "/LICENSE"
+
+	if p.Legal.Name == "None" {
+		// If user didn't set any license and an existing license file is found, use that.
+		if _, err := os.Stat(licensePath); err == nil {
+			return nil
+		}
+	}
+
+	licenseFile, err := os.Create(licensePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
GitHub now supports creating files like LICENSE for newly created repos.
Running `cobra-cli init` after cloning a newly created repo will now
empty that existing license.
