### PR TITLE
Made first letter of default toggle flag usage lowercase according to cobra conventions.

### DIFF
--- a/tpl/main.go
+++ b/tpl/main.go
@@ -157,7 +157,7 @@ func init() {
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// {{ .CmdName }}Cmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// {{ .CmdName }}Cmd.Flags().BoolP("toggle", "t", false, "help message for toggle")
 }
 `)
 }

--- a/tpl/main.go
+++ b/tpl/main.go
@@ -87,7 +87,7 @@ func init() {
 {{ end }}
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.Flags().BoolP("toggle", "t", false, "help message for toggle")
 }
 
 {{ if .Viper -}}


### PR DESCRIPTION
The first letter in the default help message for the toggle flag was uppercase, so I made it lowercase according to cobra convention.