### PR TITLE
Fix CI and README typos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 name: Test
 
 on:
@@ -16,7 +17,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: '^1.22'
 
       - uses: actions/checkout@v3.1.0
 
@@ -30,39 +31,43 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-        - ubuntu
-        - macOS
+          - ubuntu
+          - macOS
         go:
-        - 14
-        - 15
-        - 16
-        - 17
+          - 17
+          - 18
+          - 19
+          - 20
+          - 21
+          - 22
+          - 23
+          - 24
     name: '${{ matrix.platform }} | 1.${{ matrix.go }}.x'
     runs-on: ${{ matrix.platform }}-latest
     steps:
 
-    - uses: actions/setup-go@v2
-      with:
-        go-version: 1.${{ matrix.go }}.x
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.${{ matrix.go }}.x
 
-    - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3.1.0
 
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-1.${{ matrix.go }}.x-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-1.${{ matrix.go }}.x-
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-1.${{ matrix.go }}.x-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-1.${{ matrix.go }}.x-
 
-    - run: |
-        export GOBIN=$HOME/go/bin
-        case "${{ matrix.go }}" in
-          16|17) _version='@latest';;
-          *) _version='';;
-        esac
-        go install github.com/kyoh86/richgo"${_version}"
-        go install github.com/mitchellh/gox"${_version}"
+      - run: |
+          export GOBIN=$HOME/go/bin
+          case "${{ matrix.go }}" in
+            16|17) _version='@latest';;
+            *) _version='';;
+          esac
+          go install github.com/kyoh86/richgo"${_version}"
+          go install github.com/mitchellh/gox"${_version}"
 
-    - run: PATH=$HOME/go/bin/:$PATH make test build
+      - run: PATH=$HOME/go/bin/:$PATH make test build
 
   test-win:
     name: MINGW64
@@ -72,30 +77,30 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - shell: bash
-      run: git config --global core.autocrlf input
+      - shell: bash
+        run: git config --global core.autocrlf input
 
-    - uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW64
-        update: true
-        install: >
-          git
-          make
-          unzip
-          mingw-w64-x86_64-go
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >
+            git
+            make
+            unzip
+            mingw-w64-x86_64-go
 
-    - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v3.1.0
 
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.go }}-
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.go }}-
 
-    - run: |
-        export GOBIN=$HOME/go/bin
-        go install github.com/kyoh86/richgo@latest
-        go install github.com/mitchellh/gox@latest
+      - run: |
+          export GOBIN=$HOME/go/bin
+          go install github.com/kyoh86/richgo@latest
+          go install github.com/mitchellh/gox@latest
 
-    - run: PATH=$HOME/go/bin:$PATH make test build
+      - run: PATH=$HOME/go/bin:$PATH make test build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,12 +60,8 @@ jobs:
 
       - run: |
           export GOBIN=$HOME/go/bin
-          case "${{ matrix.go }}" in
-            16|17) _version='@latest';;
-            *) _version='';;
-          esac
-          go install github.com/kyoh86/richgo"${_version}"
-          go install github.com/mitchellh/gox"${_version}"
+          go install github.com/kyoh86/richgo@latest
+          go install github.com/mitchellh/gox@latest
 
       - run: PATH=$HOME/go/bin/:$PATH make test build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.22'
 
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
 
-      - uses: golangci/golangci-lint-action@v2
+      - uses: golangci/golangci-lint-action@v4.0.0
         with:
           version: latest
           args: --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,17 @@
+# Copyright 2013-2023 The Cobra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 run:
   deadline: 5m
 
@@ -5,44 +19,39 @@ linters:
   disable-all: true
   enable:
     #- bodyclose
-    - deadcode
+    # - deadcode ! deprecated since v1.49.0; replaced by 'unused'
     #- depguard
     #- dogsled
     #- dupl
     - errcheck
     #- exhaustive
     #- funlen
-    - gas
     #- gochecknoinits
     - goconst
-    #- gocritic
+    - gocritic
     #- gocyclo
-    #- gofmt
+    - gofmt
     - goimports
-    - golint
     #- gomnd
     #- goprintffuncname
-    #- gosec
-    #- gosimple
+    - gosec
+    - gosimple
     - govet
     - ineffassign
-    - interfacer
     #- lll
-    - maligned
-    - megacheck
-    #- misspell
+    - misspell
     #- nakedret
     #- noctx
-    #- nolintlint
+    - nolintlint
     #- rowserrcheck
     #- scopelint
-    #- staticcheck
-    - structcheck
-    #- stylecheck
+    - staticcheck
+    #- structcheck ! deprecated since v1.49.0; replaced by 'unused'
+    - stylecheck
     #- typecheck
     - unconvert
     #- unparam
-    #- unused
-    - varcheck
+    - unused
+    # - varcheck ! deprecated since v1.49.0; replaced by 'unused'
     #- whitespace
   fast: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# Copyright 2013-2023 The Cobra Authors
+# Copyright 2013-2025 The Cobra Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,46 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 run:
   deadline: 5m
 
 linters:
   disable-all: true
   enable:
-    #- bodyclose
+    # - bodyclose
     # - deadcode ! deprecated since v1.49.0; replaced by 'unused'
-    #- depguard
-    #- dogsled
-    #- dupl
+    # - depguard
+    # - dogsled
+    # - dupl
     - errcheck
-    #- exhaustive
-    #- funlen
-    #- gochecknoinits
+    # - exhaustive
+    # - funlen
+    # - gochecknoinits
     - goconst
     - gocritic
-    #- gocyclo
+    # - gocyclo
     - gofmt
     - goimports
-    #- gomnd
-    #- goprintffuncname
+    # - gomnd
+    # - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    #- lll
+    # - lll
     - misspell
-    #- nakedret
-    #- noctx
+    # - nakedret
+    # - noctx
     - nolintlint
-    #- rowserrcheck
-    #- scopelint
+    # - rowserrcheck
+    # - scopelint
     - staticcheck
-    #- structcheck ! deprecated since v1.49.0; replaced by 'unused'
+    # - structcheck ! deprecated since v1.49.0; replaced by 'unused'
     - stylecheck
-    #- typecheck
+    # - typecheck
     - unconvert
-    #- unparam
+    # - unparam
     - unused
     # - varcheck ! deprecated since v1.49.0; replaced by 'unused'
-    #- whitespace
+    # - whitespace
   fast: false

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It can also apply the license you specify to your application.
 With the introduction of Go modules, the Cobra generator has been simplified to
 take advantage of modules. The Cobra generator works from within a Go module. 
 
-#### Initalizing a module
+#### Initializing a module
 
 __If you already have a module, skip this step.__
 
@@ -39,7 +39,7 @@ cd myapp
 go mod init github.com/spf13/myapp
 ```
 
-#### Initalizing a Cobra CLI application
+#### Initializing a Cobra CLI application
 
 From within a Go module run `cobra-cli init`. This will create a new barebones project
 for you to edit. 
@@ -95,13 +95,13 @@ You'll notice that this final command has a `-p` flag. This is used to assign a
 parent command to the newly added command. In this case, we want to assign the
 "create" command to the "config" command. All commands have a default parent of rootCmd if not specified.  
 
-By default `cobra-cli` will append `Cmd` to the name provided and uses this name for the internal variable name. When specifying a parent, be sure to match the variable name used in the code. 
+By default `cobra-cli` will append `Cmd` to the name provided and use this name for the internal variable name. When specifying a parent, be sure to match the variable name used in the code. 
 
 *Note: Use camelCase (not snake_case/kebab-case) for command names.
 Otherwise, you will encounter errors.
 For example, `cobra-cli add add-user` is incorrect, but `cobra-cli add addUser` is valid.*
 
-Once you have run these three commands you would have an app structure similar to
+Once you have run these three commands you will have an app structure similar to
 the following:
 
 ```

--- a/cmd/golden_test.go
+++ b/cmd/golden_test.go
@@ -18,7 +18,7 @@ func init() {
 
 // ensureLF converts any \r\n to \n
 func ensureLF(content []byte) []byte {
-	return bytes.Replace(content, []byte("\r\n"), []byte("\n"), -1)
+	return bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
 }
 
 // compareFiles compares the content of files with pathA and pathB.

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -36,7 +36,7 @@ func init() {
 		// possible.
 
 		goExecutable := os.Getenv("COBRA_GO_EXECUTABLE")
-		if len(goExecutable) <= 0 {
+		if len(goExecutable) == 0 {
 			goExecutable = "go"
 		}
 

--- a/cmd/testdata/main.go.golden
+++ b/cmd/testdata/main.go.golden
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/testdata/root.go.golden
+++ b/cmd/testdata/root.go.golden
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/testdata/test.go.golden
+++ b/cmd/testdata/test.go.golden
@@ -1,5 +1,5 @@
 /*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
+Copyright © 2025 NAME HERE <EMAIL ADDRESS>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Fix `gocritic` findings:
    * Error: sloppyLen: len(goExecutable) <= 0 can be len(goExecutable) == 0 (gocritic)
    * Error: wrapperFunc: use bytes.ReplaceAll method in `bytes.Replace(content, []byte("\r\n"), []byte("\n"), -1)` (gocritic)
- Update ENV matrix in accordance to what's used in the main `cobra` repo
- Update .golangci.yml (taken from the main `cobra` repo).
- Update `actions/checkout`, `actions/setup-go@v5` and `golangci/golangci-lint-action` versions
