### PR TITLE
feat: Allow locally-scoped projects

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -22,9 +22,10 @@ import (
 )
 
 var (
-	packageName string
-	parentName  string
-	dirName     string
+	packageName      string
+	parentName       string
+	dirName          string
+	addCopyrightLine bool
 
 	addCmd = &cobra.Command{
 		Use:     "add [command name]",
@@ -67,9 +68,11 @@ Example: cobra-cli add server -> resulting in a new cmd/server.go`,
 				Project: &Project{
 					AbsolutePath: wd,
 					Legal:        getLicense(),
-					Copyright:    copyrightLine(),
 					LocalVars:    localVars,
 				},
+			}
+			if addCopyrightLine {
+				command.Copyright = copyrightLine()
 			}
 
 			cobra.CheckErr(command.Create())
@@ -83,6 +86,7 @@ func init() {
 	addCmd.Flags().StringVarP(&packageName, "package", "t", "", "target package name (e.g. github.com/spf13/hugo)")
 	addCmd.Flags().StringVarP(&parentName, "parent", "p", "rootCmd", "variable name of parent command for this command")
 	addCmd.Flags().StringVarP(&dirName, "dir", "d", "", "relative path to the command's main package")
+	addCmd.Flags().BoolVarP(&addCopyrightLine, "copyright", "c", true, "add copyright line to generated command file")
 	cobra.CheckErr(addCmd.Flags().MarkDeprecated("package", "this operation has been removed."))
 }
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -68,6 +68,7 @@ Example: cobra-cli add server -> resulting in a new cmd/server.go`,
 					AbsolutePath: wd,
 					Legal:        getLicense(),
 					Copyright:    copyrightLine(),
+					LocalVars:    localVars,
 				},
 			}
 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,6 +24,7 @@ import (
 var (
 	packageName string
 	parentName  string
+	dirName     string
 
 	addCmd = &cobra.Command{
 		Use:     "add [command name]",
@@ -54,6 +55,9 @@ Example: cobra-cli add server -> resulting in a new cmd/server.go`,
 			}
 
 			wd, err := os.Getwd()
+			if dirName != "" {
+				wd += "/" + dirName
+			}
 			cobra.CheckErr(err)
 
 			commandName := validateCmdName(args[0])
@@ -77,6 +81,7 @@ Example: cobra-cli add server -> resulting in a new cmd/server.go`,
 func init() {
 	addCmd.Flags().StringVarP(&packageName, "package", "t", "", "target package name (e.g. github.com/spf13/hugo)")
 	addCmd.Flags().StringVarP(&parentName, "parent", "p", "rootCmd", "variable name of parent command for this command")
+	addCmd.Flags().StringVarP(&dirName, "dir", "d", "", "relative path to the command's main package")
 	cobra.CheckErr(addCmd.Flags().MarkDeprecated("package", "this operation has been removed."))
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -85,6 +85,7 @@ func initializeProject(args []string) (string, error) {
 		Copyright:    copyrightLine(),
 		Viper:        viper.GetBool("useViper"),
 		AppName:      path.Base(modName),
+		LocalVars:    localVars,
 	}
 
 	if err := project.Create(); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -69,13 +69,14 @@ func initializeProject(args []string) (string, error) {
 		return "", err
 	}
 
+	modName := getModImportPath()
+
 	if len(args) > 0 {
 		if args[0] != "." {
 			wd = fmt.Sprintf("%s/%s", wd, args[0])
+			modName = fmt.Sprintf("%s/%s", modName, args[0])
 		}
 	}
-
-	modName := getModImportPath()
 
 	project := &Project{
 		AbsolutePath: wd,

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -19,6 +19,7 @@ type Project struct {
 	Legal        License
 	Viper        bool
 	AppName      string
+	LocalVars    bool
 }
 
 type Command struct {
@@ -59,7 +60,11 @@ func (p *Project) Create() error {
 	}
 	defer rootFile.Close()
 
-	rootTemplate := template.Must(template.New("root").Parse(string(tpl.RootTemplate())))
+	tmpl := tpl.RootTemplateGlobal()
+	if p.LocalVars {
+		tmpl = tpl.RootTemplateLocal()
+	}
+	rootTemplate := template.Must(template.New("root").Parse(string(tmpl)))
 	err = rootTemplate.Execute(rootFile, p)
 	if err != nil {
 		return err
@@ -107,7 +112,11 @@ func (c *Command) Create() error {
 		"title": strings.Title,
 	}
 
-	commandTemplate := template.Must(template.New("sub").Funcs(funcMap).Parse(string(tpl.AddCommandTemplate())))
+	tmpl := tpl.AddCommandTemplateGlobal()
+	if c.LocalVars {
+		tmpl = tpl.AddCommandTemplateLocal()
+	}
+	commandTemplate := template.Must(template.New("sub").Funcs(funcMap).Parse(string(tmpl)))
 	err = commandTemplate.Execute(cmdFile, c)
 	if err != nil {
 		return err

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -91,7 +91,7 @@ func (p *Project) createLicenseFile() error {
 func (c *Command) Create() error {
 	filename := c.CmdName
 	if c.CmdParent != "rootCmd" {
-		filename = fmt.Sprintf("%s-%s", strings.TrimSuffix(c.CmdParent, "Cmd"), c.CmdName)
+		filename = fmt.Sprintf("%s_%s", strings.TrimSuffix(c.CmdParent, "Cmd"), c.CmdName)
 	}
 	cmdFile, err := os.Create(fmt.Sprintf("%s/cmd/%s.go", c.AbsolutePath, filename))
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ var (
 	// Used for flags.
 	cfgFile     string
 	userLicense string
+	localVars   bool
 
 	rootCmd = &cobra.Command{
 		Use:   "cobra-cli",
@@ -48,6 +49,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("author", "a", "YOUR NAME", "author name for copyright attribution")
 	rootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "name of license for the project")
 	rootCmd.PersistentFlags().Bool("viper", false, "use Viper for configuration")
+	rootCmd.PersistentFlags().BoolVarP(&localVars, "local", "L", false, "project uses local-scoped variables")
 	cobra.CheckErr(viper.BindPFlag("author", rootCmd.PersistentFlags().Lookup("author")))
 	cobra.CheckErr(viper.BindPFlag("useViper", rootCmd.PersistentFlags().Lookup("viper")))
 	viper.SetDefault("author", "NAME HERE <EMAIL ADDRESS>")

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.15
 require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.12.0
+	golang.org/x/text v0.3.7
 )

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/spf13/cobra-cli
 
-go 1.15
+go 1.16
 
 require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.12.0
-	golang.org/x/text v0.3.7
 )

--- a/tpl/add-command.global.tmpl
+++ b/tpl/add-command.global.tmpl
@@ -1,0 +1,40 @@
+/*
+{{ .Project.Copyright }}
+{{ if .Legal.Header }}{{ .Legal.Header }}{{ end }}
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// {{ .CmdName }}Cmd represents the {{ .CmdName }} command
+var {{ .CmdName }}Cmd = &cobra.Command{
+	Use:   "{{ .CmdName }}",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("{{ .CmdName }} called")
+	},
+}
+
+func init() {
+	{{ .CmdParent }}.AddCommand({{ .CmdName }}Cmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// {{ .CmdName }}Cmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// {{ .CmdName }}Cmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/tpl/add-command.local.tmpl
+++ b/tpl/add-command.local.tmpl
@@ -1,0 +1,54 @@
+/*
+{{ .Project.Copyright }}
+{{ if .Legal.Header }}{{ .Legal.Header }}{{ end }}
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// {{ typeName .CmdName .CmdParent }} represents the {{ .CmdName }} command
+type {{ typeName .CmdName .CmdParent }} struct {
+	cmd *cobra.Command
+}
+
+func (c *{{ typeName .CmdName .CmdParent }}) RunE(_ *cobra.Command, args []string) error {
+	//Command execution goes here
+
+	fmt.Printf("running %s", c.cmd.Use)
+
+	return nil
+}
+
+func Add{{ typeName .CmdName .CmdParent }}({{.CmdParent}} *cobra.Command) {
+	{{.CmdName}} := {{ typeName .CmdName .CmdParent }}{
+		cmd: &cobra.Command{
+			Use:   "{{ .CmdName }}",
+			Short: "A brief description of your command",
+			Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+		},
+	}
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// {{.CmdName}}.cmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// {{.CmdName}}.cmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	{{.CmdParent}}.AddCommand({{.CmdName}}.cmd)
+	{{.CmdName}}.cmd.RunE = {{.CmdName}}.RunE
+
+	// Add child commands here
+	// Add{{title .CmdName}}ChildCmd({{.CmdName}}.cmd)
+}
+

--- a/tpl/add-command.local.tmpl
+++ b/tpl/add-command.local.tmpl
@@ -1,8 +1,9 @@
+{{ if or ( ne .Project.Copyright "" ) .Legal.Header }}
 /*
 {{ .Project.Copyright }}
 {{ if .Legal.Header }}{{ .Legal.Header }}{{ end }}
 */
-package cmd
+{{ end }}package cmd
 
 import (
 	"fmt"

--- a/tpl/main.go
+++ b/tpl/main.go
@@ -49,8 +49,12 @@ import (
 var cfgFile string
 {{- end }}
 
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
 // rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
+	rootCmd := &cobra.Command{
 	Use:   "{{ .AppName }}",
 	Short: "A brief description of your application",
 	Long: ` + "`" + `A longer description that spans multiple lines and likely contains
@@ -63,17 +67,6 @@ to quickly create a Cobra application.` + "`" + `,
 	// has an action associated with it:
 	// Run: func(cmd *cobra.Command, args []string) { },
 }
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
-}
-
-func init() {
 {{- if .Viper }}
 	cobra.OnInitialize(initConfig)
 {{ end }}
@@ -87,7 +80,17 @@ func init() {
 {{ end }}
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+
+	// Add child commands here
+	// AddChildCmd(rootCmd)
+
+
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
 }
 
 {{ if .Viper -}}
@@ -131,33 +134,47 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// {{ .CmdName }}Cmd represents the {{ .CmdName }} command
-var {{ .CmdName }}Cmd = &cobra.Command{
-	Use:   "{{ .CmdName }}",
-	Short: "A brief description of your command",
-	Long: ` + "`" + `A longer description that spans multiple lines and likely contains examples
+// {{ typeName .CmdName .CmdParent }} represents the {{ .CmdName }} command
+type {{ typeName .CmdName .CmdParent }} struct {
+	cmd *cobra.Command
+}
+
+func (c *{{ typeName .CmdName .CmdParent }}) RunE(_ *cobra.Command, args []string) error {
+	//Command execution goes here
+
+	fmt.Printf("running %s", c.cmd.Use)
+
+	return nil
+}
+
+func Add{{ typeName .CmdName .CmdParent }}({{.CmdParent}} *cobra.Command) {
+	{{.CmdName}} := {{ typeName .CmdName .CmdParent }}{
+		cmd: &cobra.Command{
+			Use:   "{{ .CmdName }}",
+			Short: "A brief description of your command",
+			Long: ` + "`" + `A longer description that spans multiple lines and likely contains examples
 and usage of using your command. For example:
 
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.` + "`" + `,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("{{ .CmdName }} called")
-	},
-}
-
-func init() {
-	{{ .CmdParent }}.AddCommand({{ .CmdName }}Cmd)
-
+		},
+	}
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// {{ .CmdName }}Cmd.PersistentFlags().String("foo", "", "A help for foo")
+	// {{.CmdName}}.cmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// {{ .CmdName }}Cmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// {{.CmdName}}.cmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	{{.CmdParent}}.AddCommand({{.CmdName}}.cmd)
+	{{.CmdName}}.cmd.RunE = {{.CmdName}}.RunE
+
+	// Add child commands here
+	// Add{{title .CmdName}}ChildCmd({{.CmdName}}.cmd)
 }
+
 `)
 }

--- a/tpl/main.go
+++ b/tpl/main.go
@@ -13,6 +13,10 @@
 
 package tpl
 
+import (
+	_ "embed"
+)
+
 func MainTemplate() []byte {
 	return []byte(`/*
 {{ .Copyright }}
@@ -28,153 +32,30 @@ func main() {
 `)
 }
 
-func RootTemplate() []byte {
-	return []byte(`/*
-{{ .Copyright }}
-{{ if .Legal.Header }}{{ .Legal.Header }}{{ end }}
-*/
-package cmd
+//go:embed root.local.tmpl
+var rootLocalTemplate []byte
 
-import (
-{{- if .Viper }}
-	"fmt"{{ end }}
-	"os"
-
-	"github.com/spf13/cobra"
-{{- if .Viper }}
-	"github.com/spf13/viper"{{ end }}
-)
-
-{{ if .Viper -}}
-var cfgFile string
-{{- end }}
-
-
-// Execute adds all child commands to the root command and sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-// rootCmd represents the base command when called without any subcommands
-	rootCmd := &cobra.Command{
-	Use:   "{{ .AppName }}",
-	Short: "A brief description of your application",
-	Long: ` + "`" + `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.` + "`" + `,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
-}
-{{- if .Viper }}
-	cobra.OnInitialize(initConfig)
-{{ end }}
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-{{ if .Viper }}
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.{{ .AppName }}.yaml)")
-{{ else }}
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.{{ .AppName }}.yaml)")
-{{ end }}
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
-
-	// Add child commands here
-	// AddChildCmd(rootCmd)
-
-
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+func RootTemplateLocal() []byte {
+	return rootLocalTemplate
 }
 
-{{ if .Viper -}}
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
+//go:embed root.global.tmpl
+var rootGlobalTemplate []byte
 
-		// Search config in home directory with name ".{{ .AppName }}" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".{{ .AppName }}")
-	}
-
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
-}
-{{- end }}
-`)
+func RootTemplateGlobal() []byte {
+	return rootGlobalTemplate
 }
 
-func AddCommandTemplate() []byte {
-	return []byte(`/*
-{{ .Project.Copyright }}
-{{ if .Legal.Header }}{{ .Legal.Header }}{{ end }}
-*/
-package cmd
+//go:embed add-command.local.tmpl
+var localAddCommandTemplate []byte
 
-import (
-	"fmt"
-
-	"github.com/spf13/cobra"
-)
-
-// {{ typeName .CmdName .CmdParent }} represents the {{ .CmdName }} command
-type {{ typeName .CmdName .CmdParent }} struct {
-	cmd *cobra.Command
+func AddCommandTemplateLocal() []byte {
+	return localAddCommandTemplate
 }
 
-func (c *{{ typeName .CmdName .CmdParent }}) RunE(_ *cobra.Command, args []string) error {
-	//Command execution goes here
+//go:embed add-command.global.tmpl
+var globalAddCommandTemplate []byte
 
-	fmt.Printf("running %s", c.cmd.Use)
-
-	return nil
-}
-
-func Add{{ typeName .CmdName .CmdParent }}({{.CmdParent}} *cobra.Command) {
-	{{.CmdName}} := {{ typeName .CmdName .CmdParent }}{
-		cmd: &cobra.Command{
-			Use:   "{{ .CmdName }}",
-			Short: "A brief description of your command",
-			Long: ` + "`" + `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.` + "`" + `,
-		},
-	}
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// {{.CmdName}}.cmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// {{.CmdName}}.cmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	{{.CmdParent}}.AddCommand({{.CmdName}}.cmd)
-	{{.CmdName}}.cmd.RunE = {{.CmdName}}.RunE
-
-	// Add child commands here
-	// Add{{title .CmdName}}ChildCmd({{.CmdName}}.cmd)
-}
-
-`)
+func AddCommandTemplateGlobal() []byte {
+	return globalAddCommandTemplate
 }

--- a/tpl/root.global.tmpl
+++ b/tpl/root.global.tmpl
@@ -1,0 +1,86 @@
+/*
+{{ .Copyright }}
+{{ if .Legal.Header }}{{ .Legal.Header }}{{ end }}
+*/
+package cmd
+
+import (
+{{- if .Viper }}
+	"fmt"{{ end }}
+	"os"
+
+	"github.com/spf13/cobra"
+{{- if .Viper }}
+	"github.com/spf13/viper"{{ end }}
+)
+
+{{ if .Viper -}}
+var cfgFile string
+{{- end }}
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "{{ .AppName }}",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+{{- if .Viper }}
+	cobra.OnInitialize(initConfig)
+{{ end }}
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+{{ if .Viper }}
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.{{ .AppName }}.yaml)")
+{{ else }}
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.{{ .AppName }}.yaml)")
+{{ end }}
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+{{ if .Viper -}}
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".{{ .AppName }}" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".{{ .AppName }}")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+	}
+}
+{{- end }}

--- a/tpl/root.local.tmpl
+++ b/tpl/root.local.tmpl
@@ -1,0 +1,90 @@
+/*
+{{ .Copyright }}
+{{ if .Legal.Header }}{{ .Legal.Header }}{{ end }}
+*/
+package cmd
+
+import (
+{{- if .Viper }}
+	"fmt"{{ end }}
+	"os"
+
+	"github.com/spf13/cobra"
+{{- if .Viper }}
+	"github.com/spf13/viper"{{ end }}
+)
+
+{{ if .Viper -}}
+var cfgFile string
+{{- end }}
+
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+// rootCmd represents the base command when called without any subcommands
+	rootCmd := &cobra.Command{
+	Use:   "{{ .AppName }}",
+	Short: "A brief description of your application",
+	Long: `A longer description that spans multiple lines and likely contains
+examples and usage of using your application. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	// Run: func(cmd *cobra.Command, args []string) { },
+}
+{{- if .Viper }}
+	cobra.OnInitialize(initConfig)
+{{ end }}
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+{{ if .Viper }}
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.{{ .AppName }}.yaml)")
+{{ else }}
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.{{ .AppName }}.yaml)")
+{{ end }}
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	// rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+
+	// Add child commands here
+	// AddChildCmd(rootCmd)
+
+
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+{{ if .Viper -}}
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".{{ .AppName }}" (without extension).
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".{{ .AppName }}")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+	}
+}
+{{- end }}
+


### PR DESCRIPTION
Adds a `-L` flag that tells init and add to generate based on a different template, that works without globally-scoped commands. Would be interested to hear what you think about the general approach. :)

It also puts the templates into separate files and `go:embeds` them.